### PR TITLE
Add updated links for German ENTSO-E API

### DIFF
--- a/grids/README.md
+++ b/grids/README.md
@@ -6,7 +6,7 @@ This folder serves as the main resource for all national-scale photovoltaic (PV)
 
 | Country             | Link to Detailed Info               | Primary Data Sources     | Last Updated |
 | ------------------- | ----------------------------------- | ------------------------ | ------------ |
-| Germany 🇩🇪    | [germany.md](germany.md)       | ENTOSE           | 2025-02-04   |
+| Germany 🇩🇪    | [germany.md](germany.md)       | ENTSOE           | 2025-07-12   |
 | India 🇮🇳  | [india.md](india.md) | Multiple SLDC | 2025-02-18 |
 | Netherlands 🇳🇱    | [netherlands.md](netherlands.md)       | Tennet, Ned.NL           | 2025-01-17   |
 | Great Britain 🇬🇧 | [great_britain.md](great_britain.md) | PVLive - Sheffield Solar | 2025-01-17   |

--- a/grids/germany.md
+++ b/grids/germany.md
@@ -12,6 +12,7 @@
 
 ### 1. **ENTSO-E Transparency Platform**
 - **Link**: [https://transparency.entsoe.eu/](https://transparency.entsoe.eu/)
+  - **Newer Link**: [https://newtransparency.entsoe.eu/](https://newtransparency.entsoe.eu/)
 - **Access Notes**: Free registration required. API access available with an API key.
 - **Historical Data Structure**:
   - **Temporal granularity of data**: Hourly and daily resolution
@@ -19,6 +20,7 @@
   - **Updated outturn lag?**: Typically updated with a delay of 1–2 days
 - **Other Data Types**: Includes real-time generation, load forecasts, and cross-border flows
 - **Access**: [ENTSO-E API Docs](https://transparency.entsoe.eu/content/static_content/Static%20content/web%20api/Guide.html)
+  - **Newer Link**: [Sitemap for ENTSO-E API Integration](https://transparencyplatform.zendesk.com/hc/en-us/articles/15692855254548-Sitemap-for-Restful-API-Integration)
 
 ### 2. **Open Power System Data (OPSD)**
 - **Link**: [https://open-power-system-data.org/](https://open-power-system-data.org/)

--- a/grids/germany.md
+++ b/grids/germany.md
@@ -12,6 +12,7 @@
 
 ### 1. **ENTSO-E Transparency Platform**
 - **Link**: [https://transparency.entsoe.eu/](https://transparency.entsoe.eu/)
+  - **Newer Link**: [https://newtransparency.entsoe.eu/](https://newtransparency.entsoe.eu/)
 - **Access Notes**: Free registration required. API access available with an API key.
 - **Historical Data Structure**:
   - **Temporal granularity of data**: Hourly and daily resolution
@@ -19,6 +20,7 @@
   - **Updated outturn lag?**: Typically updated with a delay of 1–2 days
 - **Other Data Types**: Includes real-time generation, load forecasts, and cross-border flows
 - **Access**: [ENTSO-E API Docs](https://transparency.entsoe.eu/content/static_content/Static%20content/web%20api/Guide.html)
+  - **Newer Link**: [ENTSO-E API Docs](https://transparencyplatform.zendesk.com/hc/en-us/articles/15692855254548-Sitemap-for-Restful-API-Integration)
 
 ### 2. **Open Power System Data (OPSD)**
 - **Link**: [https://open-power-system-data.org/](https://open-power-system-data.org/)


### PR DESCRIPTION
Minor changes to Grid documentation and newer links for ENTOSE portal. Created in relation to https://github.com/openclimatefix/solar-consumer/pull/87

## **Update: Closed PR, added as part of https://github.com/openclimatefix/solar-consumer/pull/87**