### PR TITLE
Add Portugal grid info 

### DIFF
--- a/grids/README.md
+++ b/grids/README.md
@@ -11,6 +11,7 @@ This folder serves as the main resource for all national-scale photovoltaic (PV)
 | Netherlands 🇳🇱    | [netherlands.md](netherlands.md)       | Tennet, Ned.NL           | 2025-01-17   |
 | Great Britain 🇬🇧 | [great_britain.md](great_britain.md) | PVLive - Sheffield Solar | 2025-01-17   |
 | Ireland 🇮🇪 | [ireland.md](ireland.md) | EirGrid Smart Grid | 2025-02-19 |
+| Portugal 🇵🇹 | [portugal.md](portugal.md) | REN Data Hub, APREN, ENTSO-E | 2025-01-20 |
 
 
 ## How to Add a New Grid

--- a/grids/README.md
+++ b/grids/README.md
@@ -11,7 +11,7 @@ This folder serves as the main resource for all national-scale photovoltaic (PV)
 | Netherlands 🇳🇱    | [netherlands.md](netherlands.md)       | Tennet, Ned.NL           | 2025-01-17   |
 | Great Britain 🇬🇧 | [great_britain.md](great_britain.md) | PVLive - Sheffield Solar | 2025-01-17   |
 | Ireland 🇮🇪 | [ireland.md](ireland.md) | EirGrid Smart Grid | 2025-02-19 |
-| Portugal 🇵🇹 | [portugal.md](portugal.md) | REN Data Hub, APREN, ENTSO-E | 2025-01-20 |
+| Portugal 🇵🇹 | [portugal.md](portugal.md) | REN Data Hub, APREN, ENTSO-E | 2025-08-21 |
 
 
 ## How to Add a New Grid

--- a/grids/portugal.md
+++ b/grids/portugal.md
@@ -13,7 +13,7 @@
 ## Data Sources
 
 ### 1. **REN Data Hub (Redes Energéticas Nacionais)**
-- **Link**: [https://datahub.ren.pt/](https://datahub.ren.pt/)
+- **Link**: [https://datahub.ren.pt/en/](https://datahub.ren.pt/en/)
 - **Access Notes**: Free access, no registration required for basic data. API access available.
 - **Historical Data Structure**:
   - **Temporal granularity of data**: Daily and monthly resolution
@@ -24,10 +24,10 @@
   - Monthly electricity balance and consumption evolution
   - Grid infrastructure and territory data
   - Natural gas data
-- **Access**: [API Documentation](https://datahub.ren.pt/pt/instrucoes-api/)
+- **Access**: [API Documentation](https://datahub.ren.pt/en/api-instructions/)
 
 ### 2. **APREN Monthly Bulletins (Portuguese Renewable Energy Association)**
-- **Link**: [https://www.apren.pt/dados/](https://www.apren.pt/dados/)
+- **Link**: [https://www.apren.pt/dados/en](https://www.apren.pt/dados/en)
 - **Access Notes**: Free access, monthly PDF reports available for download.
 - **Historical Data Structure**:
   - **Temporal granularity of data**: Monthly resolution

--- a/grids/portugal.md
+++ b/grids/portugal.md
@@ -1,0 +1,92 @@
+# Portugal 🇵🇹
+
+## Overview
+
+- **Key Organizations**: REN (Redes Energéticas Nacionais), DGEG (Direção-Geral de Energia e Geologia), APREN (Portuguese Renewable Energy Association), INE (Statistics Portugal), ENTSO-E Transparency Platform
+- **Data Highlights**: 
+  - Comprehensive daily and monthly electricity balance data through REN Data Hub
+  - Monthly renewable energy bulletins with solar generation statistics
+  - Real-time and historical solar generation data via ENTSO-E
+  - Official energy statistics and capacity data from government agencies
+  - High-quality solar resource data due to Portugal's excellent solar potential
+
+## Data Sources
+
+### 1. **REN Data Hub (Redes Energéticas Nacionais)**
+- **Link**: [https://datahub.ren.pt/](https://datahub.ren.pt/)
+- **Access Notes**: Free access, no registration required for basic data. API access available.
+- **Historical Data Structure**:
+  - **Temporal granularity of data**: Daily and monthly resolution
+  - **Historical data range**: 2011 to present
+  - **Updated outturn lag?**: Daily data updated with 1-2 day delay, monthly data updated monthly
+- **Other Data Types**: 
+  - Daily electricity balance including solar generation
+  - Monthly electricity balance and consumption evolution
+  - Grid infrastructure and territory data
+  - Natural gas data
+- **Access**: [API Documentation](https://datahub.ren.pt/pt/instrucoes-api/)
+
+### 2. **APREN Monthly Bulletins (Portuguese Renewable Energy Association)**
+- **Link**: [https://www.apren.pt/dados/](https://www.apren.pt/dados/)
+- **Access Notes**: Free access, monthly PDF reports available for download.
+- **Historical Data Structure**:
+  - **Temporal granularity of data**: Monthly resolution
+  - **Historical data range**: Available for several years
+  - **Updated outturn lag?**: Monthly updates
+- **Other Data Types**: 
+  - Renewable energy generation statistics
+  - Solar capacity and generation data
+  - Wind, hydro, biomass, and other renewable sources
+  - Market analysis and trends
+- **Access**: Direct download from website, no registration required
+
+### 3. **ENTSO-E Transparency Platform (Portugal)**
+- **Link**: [https://transparency.entsoe.eu/](https://transparency.entsoe.eu/)
+- **Access Notes**: Free registration required. API access available with an API key.
+- **Historical Data Structure**:
+  - **Temporal granularity of data**: Hourly and daily resolution
+  - **Historical data range**: 2015 to present
+  - **Updated outturn lag?**: Typically updated with a delay of 1–2 days
+- **Other Data Types**: 
+  - Real-time solar generation data
+  - Day-ahead and intraday forecasts
+  - Cross-border electricity flows
+  - Load and generation data
+- **Access**: [ENTSO-E API Documentation](https://transparency.entsoe.eu/content/static_content/Static%20content/web%20api/Guide.html)
+
+### 4. **DGEG Energy Statistics (Direção-Geral de Energia e Geologia)**
+- **Link**: [https://www.dgeg.gov.pt/pt/estatistica/energia/](https://www.dgeg.gov.pt/pt/estatistica/energia/)
+- **Access Notes**: Government agency providing official energy statistics. Free access.
+- **Historical Data Structure**:
+  - **Temporal granularity of data**: Monthly and annual resolution
+  - **Historical data range**: Several years of data available
+  - **Updated outturn lag?**: Monthly and annual updates
+- **Other Data Types**: 
+  - Installed capacity data
+  - Energy production statistics
+  - Renewable energy targets and progress
+  - Energy efficiency indicators
+- **Access**: Direct access through government website
+
+### 5. **INE Statistics Portugal (Energy Indicators)**
+- **Link**: [https://www.ine.pt/xportal/xmain?xpid=INE&xpgid=ine_indicadores&indOcorrCod=0008289&contexto=bd&selTab=tab2](https://www.ine.pt/xportal/xmain?xpid=INE&xpgid=ine_indicadores&indOcorrCod=0008289&contexto=bd&selTab=tab2)
+- **Access Notes**: National statistics institute. Free access to energy indicators.
+- **Historical Data Structure**:
+  - **Temporal granularity of data**: Monthly and annual resolution
+  - **Historical data range**: Long-term historical series available
+  - **Updated outturn lag?**: Monthly and annual updates
+- **Other Data Types**: 
+  - Energy consumption indicators
+  - Renewable energy share statistics
+  - Economic energy indicators
+  - Regional energy data
+- **Access**: Direct access through INE portal
+
+## Additional Comments
+
+- **Solar Resource Quality**: Portugal has excellent solar potential, particularly in the Alentejo and Algarve regions, with average annual solar irradiance of 1,700-1,900 kWh/m².
+- **Data Language**: Most data sources are available in Portuguese, with some English translations available. REN Data Hub offers bilingual access.
+- **Data Quality**: Portugal's energy data is considered highly reliable due to strict regulatory oversight and transparency requirements from EU membership.
+- **API Access**: REN provides API access for programmatic data retrieval, making it suitable for automated data collection and analysis.
+- **Integration**: Data from multiple sources can be cross-referenced for comprehensive analysis, with REN Data Hub serving as the primary real-time source and APREN providing industry analysis.
+- **Regulatory Framework**: Portugal follows EU energy transparency regulations, ensuring consistent data reporting standards and accessibility.


### PR DESCRIPTION
# Pull Request

## Description

Add comprehensive Portugal solar energy dataset entry to the global solar dataset project.

#### Changes Made
- Add Portugal entry with 5 data sources (REN Data Hub, APREN, ENTSO-E, DGEG, INE)
- Update grids README table to include Portugal
- Maintain existing project structure and ordering
- Provide English-language URLs for global accessibility

#### Data Sources Included
- **REN Data Hub**: Daily/monthly electricity balance with API access
- **APREN**: Monthly renewable energy bulletins
- **ENTSO-E**: Real-time solar generation data
- **DGEG**: Official government energy statistics
- **INE**: National statistics institute data

Fixes #37 


## Checklist:

- [X] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)
- [X] I have performed a self-review of my own code
- [X] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] I have checked my code and corrected any misspellings
