### PR TITLE
Add Belgium grid data documentation and Update the countries table

### DIFF
--- a/grids/README.md
+++ b/grids/README.md
@@ -6,6 +6,7 @@ This folder serves as the main resource for all national-scale photovoltaic (PV)
 
 | Country             | Link to Detailed Info               | Primary Data Sources     | Last Updated |
 | ------------------- | ----------------------------------- | ------------------------ | ------------ |
+| Belgium 🇧🇪    | [belgium.md](belgium.md)       | ELIA, ENTSO-E           | 2025-12-05   |
 | Germany 🇩🇪    | [germany.md](germany.md)       | ENTOSE           | 2025-02-04   |
 | India 🇮🇳  | [india.md](india.md) | Multiple SLDC | 2025-02-18 |
 | Netherlands 🇳🇱    | [netherlands.md](netherlands.md)       | Tennet, Ned.NL           | 2025-01-17   |

--- a/grids/belgium.md
+++ b/grids/belgium.md
@@ -1,0 +1,55 @@
+# Belgium 🇧🇪
+
+## Overview
+
+- **Key Organizations**: ELIA (Belgian TSO), Open Data ELIA, European Network of Transmission System Operators for Electricity (ENTSO-E)
+- **Data Highlights**: 
+  - Real-time solar and wind generation data
+  - High-quality historical archives
+  - Grid data and generation statistics
+  - Installed capacity information (11.68 GW solar as of December 2025)
+
+## Data Sources
+
+1. **Open Data ELIA**
+   - **Link**: [https://opendata.elia.be/explore/dataset/ods032/table/?sort=datetime](https://opendata.elia.be/explore/dataset/ods032/table/?sort=datetime)
+   - **Historical Data Structure**:
+     - **Temporal granularity of data**: 15-minute resolution (PT15M)
+     - **Historical date range**: 2019-11-02 to present (ongoing)
+     - **Updated outturn lag?**: Near real-time (typically within 15 minutes)
+   - **Other Data Types**: Solar power generation (measured & upscaled), forecasts, load factors
+   - **Access**: No API key required; data available in CSV and other formats
+
+2. **ELIA Grid Data Dashboard**
+   - **Link**: [https://www.elia.be/en/grid-data/generation-data/solar-power-generation](https://www.elia.be/en/grid-data/generation-data/solar-power-generation)
+   - **Historical Data Structure**:
+     - **Temporal granularity of data**: 15-minute resolution (quarter-hour)
+     - **Historical date range**: Available (variable by data type)
+     - **Updated outturn lag?**: Real-time updates (every quarter hour)
+   - **Other Data Types**: 
+     - Measured & Upscaled solar generation
+     - Day-ahead forecast (D+1, updated at 5:40 p.m.)
+     - Day-ahead forecast (D0, intraday, updated hourly)
+     - Week-ahead forecast (D+7)
+     - Most recent forecast (updated hourly)
+     - Power generation factor (relative to monitored capacity)
+     - Renewable energy breakdown
+   - **Access**: Free access; interactive dashboard with date range selection; data downloadable via ELIA Open Data platform
+   - **Monitored Capacity**: 11.68 GW (updated daily)
+
+3. **ENTSO-E Transparency Platform**
+   - **Link**: [https://transparency.entsoe.eu/](https://transparency.entsoe.eu/)
+   - **Historical Data Structure**:
+     - **Temporal granularity of data**: Hourly and daily resolution
+     - **Historical date range**: 2015 to present
+     - **Updated outturn lag?**: 1–2 days delay
+   - **Other Data Types**: Generation, load forecasts, cross-border flows
+   - **Access**: Free registration required; API access available with API key
+
+## Additional Comments
+
+- Belgium's solar capacity stands at 11.68 GW (as of December 2025), making it a significant renewable energy contributor.
+- ELIA's ODS032 dataset provides comprehensive real-time and historical 15-minute resolution data dating back to November 2019.
+- Data includes measured & upscaled values plus multiple forecast horizons (Day Ahead 11AM, Day Ahead 6PM, Week-ahead).
+- Data is available in English and Dutch on most platforms.
+- Integration with ENTSO-E data provides cross-border electricity flow information.


### PR DESCRIPTION
# Pull Request

## Description

This PR adds comprehensive documentation for the Belgium grid to the dataset.
It addresses the request to include data sources, capacity information, and dashboards for Belgium.

Changes include:
- Created `grids/Belgium.md` using the standard `GRID_TEMPLATE.md`.
- Added data sources from **Open Data ELIA** and **ENTSO-E**.
- Included real-time dashboard links and historical data specifications.
- Documented current solar capacity (11.68 GW).

Fixes #39 

## How Has This Been Tested?

I have manually verified the contributions:
- Checked that all provided URLs (ELIA Open Data, Dashboard, ENTSO-E) are active and accessible.
- Verified that the new `Belgium.md` file renders correctly in Markdown preview.
- Confirmed the capacity figures match the latest available data on the ELIA dashboard.

- [x] Yes

## Checklist:

- [x] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked my code and corrected any misspellings
